### PR TITLE
#7 setting: docker-compose와 Dockerfile 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:17
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar", "-Dspring.profiles.active=${SPRING_ACTIVE_PROFILE}","app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ configurations {
     }
 }
 
+jar {
+    enabled = false
+}
+
 repositories {
     mavenCentral()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: '3.8'
+
+networks:
+  default:
+    name: payhere2
+
+volumes:
+  data:
+    driver: local
+  config:
+    driver: local
+
+services:
+  pjh_mysql5.7:
+    image: mysql:5.7
+    container_name: pjh_mysql5.7
+    ports:
+      - 3306:3306
+    volumes:
+      - ./db/mysql/data:/var/lib/mysql
+      - ./db/mysql/init:/docker-entrypoint-initdb.d
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_USER=ledger
+      - MYSQL_PASSWORD=password
+    platform: linux/amd64
+    restart: always
+
+  pjh_mysql5.7-phpmyadmin:
+    depends_on:
+      - pjh_mysql5.7
+    image: phpmyadmin/phpmyadmin
+    container_name: pjh_mysql5.7-phpmyadmin
+    ports:
+      - 8082:80
+    environment:
+      - PMA_HOST=pjh_mysql5.7
+      - MYSQL_ROOT_PASSWORD=password
+    platform: linux/amd64
+    restart: always
+  pjh_redis:
+    image: redis
+    container_name: pjh_redis
+    ports:
+      - 6379:6379
+  pjh_ledger_application:
+    build: .
+    environment:
+      - MYSQL_HOST=pjh_mysql5.7
+      - REDIS_HOST=pjh_redis
+      - SPRING_ACTIVE_PROFILE=local
+    ports:
+      - 8080:8080
+    depends_on:
+      - pjh_mysql5.7
+      - pjh_redis
+    container_name: pjh_ledger_application
+    restart: on-failure

--- a/dockerize.sh
+++ b/dockerize.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+./gradlew clean :bootJar
+
+docker build --force-rm -t ${IMG_NAME:-financial-ledger_pjh_ledger_application} .

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,7 +3,7 @@ spring:
     driver-class-name: com.mysql.jdbc.Driver
     username: ${MYSQL_USERNAME:root}
     password: ${MYSQL_PASSWORD:password}
-    url: jdbc:mysql://localhost:3306/${MYSQL_SCHEMA:ledger}
+    url: jdbc:mysql://${MYSQL_HOST:localhost}:3306/${MYSQL_SCHEMA:ledger}
   jpa:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     show-sql: ${SHOW_SQL:true}


### PR DESCRIPTION
## 설명
docker로 실행가능한 환경을 구축합니다.
## 작업 리스트
[setting:](https://github.com/pjh612/financial-ledger/commit/8e3af65a95c195e89f771c088186da091fd1468f) https://github.com/pjh612/financial-ledger/issues/7 [docker-compose와 Dockerfile 추가](https://github.com/pjh612/financial-ledger/commit/8e3af65a95c195e89f771c088186da091fd1468f)
- [x] Dockerfile 만들기
- [x] 도커 이미지 만들기
- [x] 도커 컴포즈 활용
## 작업 상세 내용
빌드된 jar파일을 Docker Image로 만들 수 있도록 Dockerfile을 만들었습니다. 아래 명령어로 도커 이미지를 빌드 할 수 있습니다.

```
 docker build -t financial-ledger_pjh_ledger_application . 
```

docker-compose.yml 파일도 추가 했습니다. 한번에 redis, mysql, mysql-php, application을 도커 환경에서 구동할 수 있습니다. 다음 명령어를 사용하세요
```
 docker-compose up
```

dockerize.sh 스크립트 파일은 jar파일 생성과 이미지 빌드를 한번에 실행할 수 있도록 간단하게 스크립트를 작성했습니다. 다음 명령어를 사용하세요
```
sh dockerize.sh
```
