### PR TITLE
#15 test: 통합 테스트 환경에서 EmbeddedRedis 사용하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
     //REDIS
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
+    testImplementation 'it.ozimov:embedded-redis:0.7.2'
     //FLYWAY
     implementation "org.flywaydb:flyway-mysql"
     implementation 'org.flywaydb:flyway-core:7.15.0'

--- a/src/test/java/in/payhere/financialledger/auth/controller/AuthControllerTest.java
+++ b/src/test/java/in/payhere/financialledger/auth/controller/AuthControllerTest.java
@@ -33,11 +33,11 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import in.payhere.financialledger.auth.service.dto.response.JwtToken;
 import in.payhere.financialledger.auth.controller.request.SignInWebRequest;
+import in.payhere.financialledger.auth.service.AuthService;
+import in.payhere.financialledger.auth.service.dto.response.JwtToken;
 import in.payhere.financialledger.auth.service.dto.response.SignInResponse;
 import in.payhere.financialledger.auth.service.dto.response.SignOutResponse;
-import in.payhere.financialledger.auth.service.AuthService;
 import in.payhere.financialledger.common.ApiResponse;
 import in.payhere.financialledger.common.config.SecurityConfig;
 import in.payhere.financialledger.common.config.properties.JwtConfigureProperties;
@@ -50,10 +50,11 @@ import in.payhere.financialledger.common.security.jwt.JwtAuthentication;
 import in.payhere.financialledger.common.security.jwt.JwtAuthenticationToken;
 import in.payhere.financialledger.common.security.jwt.JwtProvider;
 import in.payhere.financialledger.common.security.jwt.TokenService;
+import in.payhere.financialledger.security.WithMockJwtAuthentication;
 
 @WebMvcTest({AuthController.class, SecurityConfig.class, JwtConfigureProperties.class, JwtProvider.class,
 	TokenService.class})
-public class AuthControllerTest {
+class AuthControllerTest {
 
 	@Autowired
 	MockMvc mockMvc;
@@ -205,9 +206,10 @@ public class AuthControllerTest {
 
 	@Test
 	@DisplayName("로그아웃 성공")
+	@WithMockJwtAuthentication
 	void signOutSuccess() throws Exception {
 		//given
-		setTestAuthentication();
+		//setTestAuthentication();
 		JwtToken accessToken = new JwtToken("at", "accessToken", 30L);
 		JwtToken refreshToken = new JwtToken("rt", "refreshToken", 60L);
 

--- a/src/test/java/in/payhere/financialledger/config/TestRedisConfig.java
+++ b/src/test/java/in/payhere/financialledger/config/TestRedisConfig.java
@@ -1,9 +1,13 @@
-package in.payhere.financialledger.common.config;
+package in.payhere.financialledger.config;
+
+import java.io.IOException;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -11,15 +15,29 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import in.payhere.financialledger.common.config.properties.RedisConfigProperties;
-import lombok.RequiredArgsConstructor;
+import redis.embedded.RedisServer;
 
-@Profile("local")
-@RequiredArgsConstructor
 @Configuration
 @EnableRedisRepositories
 @EnableConfigurationProperties(RedisConfigProperties.class)
-public class RedisConfig {
-	private final RedisConfigProperties redisConfigProperties;
+public class TestRedisConfig {
+	private RedisServer redisServer;
+	private RedisConfigProperties redisConfigProperties;
+
+	public TestRedisConfig(RedisConfigProperties redisConfigProperties) {
+		this.redisConfigProperties = redisConfigProperties;
+		redisServer = new RedisServer(redisConfigProperties.port());
+	}
+
+	@PostConstruct
+	public void startRedis() throws IOException {
+		redisServer.start();
+	}
+
+	@PreDestroy
+	public void stopRedis() {
+		redisServer.stop();
+	}
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {

--- a/src/test/java/in/payhere/financialledger/ledgers/controller/LedgerControllerTest.java
+++ b/src/test/java/in/payhere/financialledger/ledgers/controller/LedgerControllerTest.java
@@ -131,8 +131,6 @@ class LedgerControllerTest {
 	@WithMockJwtAuthentication
 	void recordNegativeAmountFail() throws Exception {
 		CreateLedgerRecordWebRequest createLedgerRequest = new CreateLedgerRecordWebRequest(
-			1L,
-			1L,
 			-2000,
 			"memo",
 			LocalDateTime.now(),
@@ -142,7 +140,7 @@ class LedgerControllerTest {
 		ErrorResponse<ErrorModel> response = new ErrorResponse<>(ErrorCode.METHOD_ARGUMENT_NOT_VALID);
 
 		//when
-		ResultActions perform = mockMvc.perform(post("/api/ledgers/records")
+		ResultActions perform = mockMvc.perform(post("/api/ledgers/{ledgerId}/records", 1L)
 			.content(request)
 			.contentType(MediaType.APPLICATION_JSON)
 		).andDo(print());

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,7 +19,7 @@ security:
     client-secret: TEST_SECRET
 redis:
   host: ${REDIS_HOST:localhost}
-  port: ${REDIS_PORT:6379}
+  port: ${REDIS_PORT:6399}
 
 cookie:
   secure: false


### PR DESCRIPTION
## 설명
통합 테스트 환경에서 EmbeddedRedis 사용하도록 변경
## 작업 리스트
[test:](https://github.com/pjh612/financial-ledger/commit/8e130a9e50a20fdf2f1f49f29e0cb6a750f76bc4) https://github.com/pjh612/financial-ledger/issues/15 [DTO 스펙변경에 따른 테스트코드 수정](https://github.com/pjh612/financial-ledger/commit/8e130a9e50a20fdf2f1f49f29e0cb6a750f76bc4)
 
[test:](https://github.com/pjh612/financial-ledger/commit/8be84c6c66d894cf1e93fcc3257f93a480a44164) https://github.com/pjh612/financial-ledger/issues/15 [테스트 용 Embedded Redis 사용](https://github.com/pjh612/financial-ledger/commit/8be84c6c66d894cf1e93fcc3257f93a480a44164)

## 작업 상세 내용

- DTO 스펙변경이 테스트코드에 반영되지 않아 수정했습니다.

- 테스트 환경에서는 별도의 테스트용 EmbeddedRedis를 사용하도록 it.ozimov:embedded-redis:0.7.2 를 사용했습니다.