### PR TITLE
feat: #17 이메일 인증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,15 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'commons-io:commons-io:2.11.0'
+
+    // WEBJARS - AXIOS
+    implementation 'org.webjars.npm:axios:0.27.2'
+
+    //EMAIL
+    implementation 'org.springframework.boot:spring-boot-starter-mail:2.7.5'
+
+    //THYMELEAF
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/in/payhere/financialledger/common/exception/BusinessException.java
+++ b/src/main/java/in/payhere/financialledger/common/exception/BusinessException.java
@@ -12,6 +12,11 @@ public class BusinessException extends RuntimeException {
 		this.errorModel = errorModel;
 	}
 
+	public BusinessException(Throwable cause, ErrorModel errorModel) {
+		super(cause);
+		this.errorModel = errorModel;
+	}
+
 	public ErrorModel errorModel() {
 		return errorModel;
 	}

--- a/src/main/java/in/payhere/financialledger/common/exception/ErrorCode.java
+++ b/src/main/java/in/payhere/financialledger/common/exception/ErrorCode.java
@@ -20,7 +20,16 @@ public enum ErrorCode implements ErrorModel {
 
 	//LEDGER
 	NOT_FOUND_LEDGER("L001", "Not found data", HttpStatus.NOT_FOUND),
-	NOT_FOUND_LEDGER_RECORD("L002", "Not found data", HttpStatus.NOT_FOUND);
+	NOT_FOUND_LEDGER_RECORD("L002", "Not found data", HttpStatus.NOT_FOUND),
+
+	//EMAIL_TOKEN
+	NOT_VERIFIED_EMAIL("E001", "Not verified email", HttpStatus.BAD_REQUEST),
+	NOT_FOUND_VERIFICATION_TOKEN("E002", "Not found data", HttpStatus.BAD_REQUEST),
+	UPDATE_VERIFICATION_TOKEN_EXCEPTION("E003", "Cannot update verification token", HttpStatus.BAD_REQUEST),
+	NOT_VALID_VERIFICATION_TOKEN("E004", "Not valid verification token", HttpStatus.BAD_REQUEST),
+
+	//MAIL
+	MAIL_SEND_FAIL("M001", "Mail send failed", HttpStatus.INTERNAL_SERVER_ERROR);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/in/payhere/financialledger/user/controller/ConfirmEmailWebRequest.java
+++ b/src/main/java/in/payhere/financialledger/user/controller/ConfirmEmailWebRequest.java
@@ -1,0 +1,4 @@
+package in.payhere.financialledger.user.controller;
+
+public record ConfirmEmailWebRequest(String email, String token) {
+}

--- a/src/main/java/in/payhere/financialledger/user/controller/EmailCheckWebRequest.java
+++ b/src/main/java/in/payhere/financialledger/user/controller/EmailCheckWebRequest.java
@@ -1,0 +1,4 @@
+package in.payhere.financialledger.user.controller;
+
+public record EmailCheckWebRequest(String email) {
+}

--- a/src/main/java/in/payhere/financialledger/user/controller/UserController.java
+++ b/src/main/java/in/payhere/financialledger/user/controller/UserController.java
@@ -1,26 +1,18 @@
 package in.payhere.financialledger.user.controller;
 
-import javax.validation.Valid;
-
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
-import in.payhere.financialledger.common.ApiResponse;
-import in.payhere.financialledger.user.controller.request.SignUpWebRequest;
-import in.payhere.financialledger.user.service.UserService;
-import in.payhere.financialledger.user.service.dto.response.SignUpResponse;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/users")
-@RestController
+@RequestMapping("/users")
+@Controller
 public class UserController {
-	private final UserService userService;
 
-	@PostMapping("/signup")
-	public ApiResponse<SignUpResponse> signUp(@RequestBody @Valid SignUpWebRequest request) {
-		return new ApiResponse<>(userService.signUp(request.email(), request.password()));
+	@GetMapping("/signup")
+	public String signUp() {
+		return "signup";
 	}
 }

--- a/src/main/java/in/payhere/financialledger/user/controller/UserRestController.java
+++ b/src/main/java/in/payhere/financialledger/user/controller/UserRestController.java
@@ -1,0 +1,47 @@
+package in.payhere.financialledger.user.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.payhere.financialledger.common.ApiResponse;
+import in.payhere.financialledger.user.controller.request.SignUpWebRequest;
+import in.payhere.financialledger.user.service.MailService;
+import in.payhere.financialledger.user.service.UserService;
+import in.payhere.financialledger.user.service.dto.response.SignUpResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@RestController
+public class UserRestController {
+	private final UserService userService;
+	private final MailService mailService;
+
+	@PostMapping("/signup")
+	public ApiResponse<SignUpResponse> signUp(@RequestBody @Valid SignUpWebRequest request) {
+		return new ApiResponse<>(userService.signUp(request.email(), request.password()));
+	}
+
+	@PatchMapping("/emails/verification")
+	public ResponseEntity<Void> emailConfirm(@RequestBody ConfirmEmailWebRequest request) {
+		mailService.verify(request.email(), request.token());
+
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/emails/verification/token")
+	public ResponseEntity<Void> emailCheck(@RequestBody EmailCheckWebRequest request) throws Exception {
+		mailService.sendVerificationEmail(request.email());
+
+		return ResponseEntity.ok().build();
+	}
+
+}

--- a/src/main/java/in/payhere/financialledger/user/entity/EmailToken.java
+++ b/src/main/java/in/payhere/financialledger/user/entity/EmailToken.java
@@ -1,0 +1,89 @@
+package in.payhere.financialledger.user.entity;
+
+import static java.text.MessageFormat.format;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import in.payhere.financialledger.common.exception.BusinessException;
+import in.payhere.financialledger.common.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class EmailToken {
+
+	private static final long EMAIL_TOKEN_EXPIRATION_TIME_VALUE = 5L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Column(unique = true)
+	private String email;
+
+	private String token;
+
+	private LocalDateTime expireAt;
+
+	private boolean isVerified;
+
+	private LocalDate sentDate;
+
+	private int sentCount;
+
+	private EmailToken(String email, String token, LocalDateTime expireAt, boolean isVerified, LocalDate sentDate,
+		int sentCount) {
+		this.email = email;
+		this.token = token;
+		this.expireAt = expireAt;
+		this.isVerified = isVerified;
+		this.sentDate = sentDate;
+		this.sentCount = sentCount;
+	}
+
+	public static EmailToken createEmailToken(String email, String token) {
+		return new EmailToken(email, token, LocalDateTime.now().plusMinutes(EMAIL_TOKEN_EXPIRATION_TIME_VALUE), false,
+			LocalDate.now(), 1);
+	}
+
+	public boolean isVerified() {
+		return this.isVerified;
+	}
+
+	public void verify(String token) {
+		if (this.token.equals(token) && expireAt.isAfter(LocalDateTime.now())) {
+			this.isVerified = true;
+		}
+
+		throw new BusinessException(ErrorCode.NOT_VALID_VERIFICATION_TOKEN, format("token : {0} is not valid", token));
+	}
+
+	public void updateToken(String token) {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDate today = now.toLocalDate();
+		boolean isAfterLastSentDate = today.isAfter(this.sentDate);
+		if (isAfterLastSentDate) {
+			this.sentCount = 1;
+			this.sentDate = today;
+		} else if (this.expireAt.isAfter(now)) {
+			throw new BusinessException(ErrorCode.UPDATE_VERIFICATION_TOKEN_EXCEPTION, "You can send it once every five minutes.");
+		} else if (this.sentCount > 2) {
+			throw new BusinessException(ErrorCode.UPDATE_VERIFICATION_TOKEN_EXCEPTION, "You can only send three times a day.");
+		} else {
+			this.sentCount++;
+		}
+
+		this.token = token;
+		this.isVerified = false;
+		this.expireAt = now.plusMinutes(EMAIL_TOKEN_EXPIRATION_TIME_VALUE);
+	}
+}

--- a/src/main/java/in/payhere/financialledger/user/service/EmailTokenRepository.java
+++ b/src/main/java/in/payhere/financialledger/user/service/EmailTokenRepository.java
@@ -1,0 +1,12 @@
+package in.payhere.financialledger.user.service;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import in.payhere.financialledger.user.entity.EmailToken;
+
+public interface EmailTokenRepository extends JpaRepository<EmailToken, Long> {
+	Optional<EmailToken> findByEmail(@Param("email") String email);
+}

--- a/src/main/java/in/payhere/financialledger/user/service/MailService.java
+++ b/src/main/java/in/payhere/financialledger/user/service/MailService.java
@@ -1,0 +1,95 @@
+package in.payhere.financialledger.user.service;
+
+import static java.text.MessageFormat.format;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import in.payhere.financialledger.common.exception.BusinessException;
+import in.payhere.financialledger.common.exception.EntityNotFoundException;
+import in.payhere.financialledger.common.exception.ErrorCode;
+import in.payhere.financialledger.user.entity.EmailToken;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class MailService {
+	private final JavaMailSender mailSender;
+	private final EmailTokenRepository emailTokenRepository;
+	private final TemplateEngine templateEngine;
+
+	@Transactional
+	public void sendVerificationEmail(String to) throws Exception {
+		String token = createToken();
+		Map<String, Object> variables = Map.of("token", token);
+		emailTokenRepository.findByEmail(to)
+			.ifPresentOrElse(emailToken -> emailToken.updateToken(token),
+				() -> emailTokenRepository.save(EmailToken.createEmailToken(to, token)));
+
+		MimeMessage message = createMessage(to, "FINANCIAL-LEDGER 회원가입 이메일 인증", "token-mail", variables);
+		try {
+			mailSender.send(message);
+		} catch (MailException es) {
+			throw new BusinessException(es, ErrorCode.MAIL_SEND_FAIL);
+		}
+	}
+
+	private String createToken() {
+		StringBuilder token = new StringBuilder();
+		Random random = new Random();
+
+		IntStream.range(0, 8)
+			.map(i -> random.nextInt(3))
+			.map(caseNumber ->
+				switch (caseNumber) {
+					case 0 -> random.nextInt(26) + 97;
+					case 1 -> (char)(random.nextInt(26) + 65);
+					case 2 -> random.nextInt(10);
+					default -> throw new IllegalStateException("Unexpected value: " + caseNumber);
+				}
+			).forEach(token::append);
+
+		return token.toString();
+	}
+
+	private MimeMessage createMessage(String to, String subject, String templateName, Map<String, Object> variables)
+		throws MessagingException, UnsupportedEncodingException {
+		MimeMessage mimeMessage = mailSender.createMimeMessage();
+		mimeMessage.addRecipients(MimeMessage.RecipientType.TO, to);
+		mimeMessage.setSubject(subject);
+		mimeMessage.setText(setContext(templateName, variables), "utf-8", "html");
+		mimeMessage.setFrom(new InternetAddress("gksfk612@naver.com", "ledger-admin"));
+
+		return mimeMessage;
+	}
+
+	private String setContext(String templateName, Map<String, Object> variables) {
+		Context context = new Context();
+		context.setVariables(variables);
+
+		return templateEngine.process(templateName, context);
+	}
+
+	@Transactional
+	public void verify(String email, String token) {
+		emailTokenRepository.findByEmail(email)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_VERIFICATION_TOKEN,
+				format("Not found verification token of email {}", email)))
+			.verify(token);
+	}
+}

--- a/src/main/java/in/payhere/financialledger/user/service/UserService.java
+++ b/src/main/java/in/payhere/financialledger/user/service/UserService.java
@@ -1,18 +1,20 @@
 package in.payhere.financialledger.user.service;
 
-import java.text.MessageFormat;
+import static java.text.MessageFormat.format;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.payhere.financialledger.common.exception.BusinessException;
 import in.payhere.financialledger.common.exception.EntityNotFoundException;
 import in.payhere.financialledger.common.exception.ErrorCode;
 import in.payhere.financialledger.user.converter.UserConverter;
-import in.payhere.financialledger.user.service.dto.response.SignUpResponse;
-import in.payhere.financialledger.user.service.dto.response.UserResponse;
+import in.payhere.financialledger.user.entity.EmailToken;
 import in.payhere.financialledger.user.entity.User;
 import in.payhere.financialledger.user.repository.UserRepository;
+import in.payhere.financialledger.user.service.dto.response.SignUpResponse;
+import in.payhere.financialledger.user.service.dto.response.UserResponse;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -20,11 +22,17 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class UserService {
 	private final UserRepository userRepository;
+	private final EmailTokenRepository emailTokenRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final UserConverter userConverter;
 
 	@Transactional
 	public SignUpResponse signUp(String email, String password) {
+		EmailToken emailToken = emailTokenRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+		if (!emailToken.isVerified()) {
+			throw new BusinessException(ErrorCode.NOT_VERIFIED_EMAIL, format("email : {0} is not verified.", email));
+		}
+
 		password = passwordEncoder.encode(password);
 		User newUser = userRepository.save(new User(email, password));
 
@@ -34,7 +42,7 @@ public class UserService {
 	public UserResponse findByEmail(String email) {
 		User foundUser = userRepository.findByEmail(email)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER,
-				MessageFormat.format("email : {0} not found", email)));
+				format("email : {0} not found", email)));
 
 		return userConverter.toUserResponse(foundUser);
 	}
@@ -42,7 +50,7 @@ public class UserService {
 	public UserResponse findById(Long userId) {
 		User foundUser = userRepository.findById(userId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_USER,
-				MessageFormat.format("userId : {0} not found", userId)));
+				format("userId : {0} not found", userId)));
 
 		return userConverter.toUserResponse(foundUser);
 	}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,15 +11,31 @@ spring:
   redis:
     host: ${REDIS_HOST:localhost}
     port: ${REDIS_PORT:6379}
-
+  mail:
+    host: smtp.naver.com
+    port: 465
+    username: ${SMTP_EMAIL}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+          auth: true
+          ssl:
+            trust: smtp.naver.com
+            enable: true
 security:
   patterns:
     ignoring:
-      GET: [ ]
+      GET:
+        - /users/signup
       POST:
         - /api/users/signup
         - /api/users/signin
-      PATCH: [ ]
+        - /api/users/email-check
+      PATCH:
+        - /api/users/email-confirm
       PUT: [ ]
       DELETE: [ ]
     permit-all:

--- a/src/main/resources/db/migration/V3_0__create_table_email_token.sql
+++ b/src/main/resources/db/migration/V3_0__create_table_email_token.sql
@@ -1,0 +1,8 @@
+CREATE TABLE email_token
+(
+    id         BIGINT       NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    email      VARCHAR(255) NOT NULL UNIQUE ,
+    token      VARCHAR(300) NOT NULL,
+    expire_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    is_verified BOOLEAN      NOT NULL DEFAULT FALSE
+);

--- a/src/main/resources/db/migration/V3_1__alter_table_email_token.sql
+++ b/src/main/resources/db/migration/V3_1__alter_table_email_token.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE email_token ADD sent_date date;
+ALTER TABLE email_token ADD sent_count int;

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -1,0 +1,81 @@
+<html lang="en">
+<head>
+    <script src="/webjars/axios/0.27.2/dist/axios.js"></script>
+    <title>회원가입</title>
+</head>
+<script>
+    function signUpRequest() {
+        axios
+            .post("/api/users/signup",
+                {
+                    headers: {
+                        'Content-type': 'application/json',
+                    },
+                    email: document.getElementById("email").value,
+                    password: document.getElementById("password").value,
+                }
+            )
+            .then(response => {
+                window.location.href = "http://localhost:8080/users/signin";
+            })
+            .catch(error => {
+                alert("오류가 발생했습니다. \n" + error);
+            })
+    }
+
+    function mailCheck() {
+        axios
+            .post("/api/users/emails/verification/token",
+                {
+                    headers: {
+                        'Content-type': 'application/json',
+                    },
+                    email: document.getElementById("email").value,
+                }
+            )
+            .then(response => {
+                alert("인증메일 전송 완료");
+            })
+            .catch(error => {
+                alert("오류가 발생했습니다.\n" + error);
+            })
+    }
+
+    function mailConfirm() {
+        axios.patch("/api/users/verification",
+                {
+                    headers: {
+                        'Content-type': 'application/json',
+                    },
+                    email: document.getElementById("email").value,
+                    token: document.getElementById("token").value,
+                }
+            )
+            .then(response => {
+                alert("메일 인증 완료");
+            })
+            .catch(error => {
+                alert("메일 인증 실패.\n" + error);
+            })
+    }
+</script>
+<body>
+
+    <div>
+        <input type="text" id="email" name="email" placeholder="사용자 이메일">
+    </div>
+    <div>
+        <input type="password" id="password" name="password" placeholder="비밀번호">
+    </div>
+    <button onclick="mailCheck()">인증메일 전송</button>
+
+    <div>
+        <input type="text" id="token" name="token" placeholder="인증번호">
+        <button onclick="mailConfirm()">이메일 확인</button>
+    </div>
+
+    <div>
+        <button onclick="signUpRequest()">회원가입</button>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/token-mail.html
+++ b/src/main/resources/templates/token-mail.html
@@ -1,0 +1,16 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<body>
+<div style='margin:100px'>
+    <h1> 안녕하세요</h1>
+    <h1> financial-ledger 입니다</h1>
+    <br>
+    <p>아래 코드를 회원가입 창으로 돌아가 입력해주세요</p>
+    <br>
+    <div align='center' style='border:1px solid black; font-family:verdana' ;>
+        <h3 style='color:blue;'>회원가입 인증 코드입니다.</h3>
+        <div style='font-size:130%'>
+            CODE = <strong th:text="${token}"></strong>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/test/java/in/payhere/financialledger/user/controller/UserControllerTest.java
+++ b/src/test/java/in/payhere/financialledger/user/controller/UserControllerTest.java
@@ -30,7 +30,7 @@ import in.payhere.financialledger.user.controller.request.SignUpWebRequest;
 import in.payhere.financialledger.user.service.UserService;
 import in.payhere.financialledger.user.service.dto.response.SignUpResponse;
 
-@WebMvcTest({UserController.class, SecurityConfig.class})
+@WebMvcTest({UserRestController.class, SecurityConfig.class})
 public class UserControllerTest {
 
 	@Autowired


### PR DESCRIPTION
## 설명
회원 가입 시 이메일 인증 기능을 추가합니다.
## 작업 리스트
[feat:](https://github.com/pjh612/financial-ledger/commit/1d26d957246e8a53c3cd65bb154d63703b47d647) https://github.com/pjh612/financial-ledger/issues/17 [이메일 인증 기능 추가](https://github.com/pjh612/financial-ledger/commit/1d26d957246e8a53c3cd65bb154d63703b47d647)

## 작업 상세 내용
- EmailToken Entity를 추가 했습니다.
  - sentDate, sentCount로 인증 메일 재전송 로직을 제어합니다.
  - 인증 코드 만료 기간은 5분입니다.
  - 5분에 한번 인증 메일을 보낼 수 있습니다.
  - 하루에 3번 인증 메일을 보낼 수 있습니다.
- 메일 내용은 타임리프 템플릿으로 처리합니다. (token-mail.html)
- 인증 토큰은 소문자, 대문자, 숫자 혼합 8 자리입니다.
- 회원 가입 시 이메일 인증이 되지 않았다면 가입할 수 없도록 회원 가입 로직에 추가 했습니다.

